### PR TITLE
Add class hierarchy for class Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,26 @@
 
 Compiler Construction,
 Innopolis University
+
+# Evaluation
+Program is a sequence of elements. Each element is evaluated as soon as it is parsed.
+
+## How to evaluate element
+- If it is a literal, just return its value
+- If it is an atom, try to lookup its value in Context, otherwise throw error (?)
+- If it is a list, evaluate it and return the result
+
+## How to evaluate list
+- If first value is an atom (identifier, e.g. `minus` or `my_func`, treat it as a function call:
+    - Check number of arguments (separated by whitespaces, not a single list)
+    - Evaluate each argument (recursively, each argument is an element)
+    - Evaluate function with the arguments (should be evaluated to literals)
+    - Return result
+- Otherwise (if first value is a literal or list), treat it as just a list (literal) and return it as it is
+
+## Note on my current idea of storing functions (any suggestions?) (Delete later this part)
+
+Create objects of class `Function` (for default functions) and pass the handler 
+(reference to function) as an argument. Dictionary should now store `Function *` as a value.
+Also, now we can move the number of arguments check to the class `Function`, so we don't need it
+in the handlers as well.

--- a/semantic.cpp
+++ b/semantic.cpp
@@ -59,44 +59,64 @@ private:
     // TODO define other functions
 };
 
-// This class should be instantiated for predefined functions only
 class Function : public Element {
-private:
-    std::string name{"__lambda__"};
+protected:
+    std::string name{};
     std::vector<std::string> *args;
     int args_number;
-    FunctionPointer handler{};
-    Context *context;
-
     bool lambda{false};
 
-public:
-    Function(std::string name, std::vector<std::string> *args,
-             Context *context, FunctionPointer handler = nullptr) :
-            name(name), args(args), args_number(args->size()), handler(handler), context(context) {};
+    Function(std::string name, std::vector<std::string> *args) :
+            name(name), args(args), args_number(args->size()) {};
 
     // Context here so that predefined functions can access it
-    Element *eval(Context* currContext, List *args) {
-        return this->handler(this->context, args);
+    virtual Element *eval(Context *currContext, List *args) {
+        return nullptr;
+    };
+
+    bool validate_args_number(int given_number) {
+        return given_number == this->args_number;
     }
 
-    // # TODO maybe?
-    void print() override {}
+    // # TODO write print method
+    void print() override {
+    }
+};
+
+
+// This class should be instantiated for predefined functions only
+class PredefinedFunction : public Function {
+private:
+    FunctionPointer handler{};
+
+public:
+    PredefinedFunction(std::string name, std::vector<std::string> *args, Context *context, FunctionPointer handler) :
+            Function(name, args), handler(handler) {};
+
+    Element *eval(Context *currContext, List *args) override {
+        return this->handler(currContext, args);
+    }
 };
 
 class CustomFunction : public Function {
-private:
+protected:
     std::vector<Element *> *body;
+    Context *localContext;
 public:
     CustomFunction(std::string name, std::vector<std::string> *args, std::vector<Element *> *body,
-                   Context *currContext) : Function(name, args, currContext) {};
+                   Context *localContext) : Function(name, args), body(body), localContext(localContext) {};
 
-    Element *eval(Context *context, List *args) {
+    Element *eval(Context *currContext, List *args) override {
 
-        // Context MUSTN'T be used here, for uniformity
-
-        // if body is literal, simply return its value
+        // Context MUST NOT be used here, need it because of override
+        // TODO implement this (using predefined eval probably)
+        this->localContext.get()
     }
+};
+
+class LambdaFunction : public CustomFunction {
+    LambdaFunction(std::vector<std::string> *args, std::vector<Element *> *body, Context *localContext):
+                CustomFunction("<lambda_func>", args, body, localContext), lambda(true){};
 };
 
 class Context {

--- a/semantic.cpp
+++ b/semantic.cpp
@@ -59,31 +59,39 @@ private:
     // TODO define other functions
 };
 
+// This class should be instantiated for predefined functions only
 class Function : public Element {
 private:
-    std::string name{};
-    std::vector<std::string> *args{};
-    Element *body;
+    std::string name{"__lambda__"};
+    std::vector<std::string> *args;
+    int args_number;
+    FunctionPointer handler{};
+    Context *context;
+
+    bool lambda{false};
 
 public:
-    Function(Atom *name, List *args, Element *body): body(body) {
-        if(name != nullptr && !name->identifier.empty()){
-            this->name = name->identifier;
-        }
-        // else it is nullptr by default
+    Function(std::string name, std::vector<std::string> *args, FunctionPointer handler, Context *currContext) :
+            name(name), args(args), args_number(args->size()), handler(handler), context(currContext) {}
 
-        for(auto elem: args->elements) {
-            try {
-                Atom *arg = (Atom *) elem;
-                this->args->push_back(arg->identifier);
-            }
-            catch (std::exception &) {
-                // invalid element type exception, must be atom
-            }
-        }
+    Element *eval(List *args) {
+        return this->handler(this->context, args);
     }
 
-    Element eval(Context* context, List *args){
+    // # TODO maybe?
+    void print() override {}
+};
+
+class CustomFunction : public Function {
+private:
+    std::vector<Element *> *body;
+public:
+    CustomFunction(std::string name, std::vector<std::string> *args, std::vector<Element *> *body,
+                   Context *currContext) : Function(name, args, (CustomFunction::eval), currContext) {};
+
+    static Element* eval(Context* context, List *args) {
+        // Context MUSTN'T be used here, for uniformity
+
         // if body is literal, simply return its value
 
         // else if body is atom, try to look it up in context dict, and throw exception if does not exist
@@ -93,11 +101,7 @@ public:
 
         // if it's a list, create new context (copy), execute statements one by one, return result.
     }
-
-    // # TODO maybe?
-    void print() override {}
 };
-
 
 class Context {
 private:

--- a/semantic.cpp
+++ b/semantic.cpp
@@ -71,10 +71,12 @@ private:
     bool lambda{false};
 
 public:
-    Function(std::string name, std::vector<std::string> *args, FunctionPointer handler, Context *currContext) :
-            name(name), args(args), args_number(args->size()), handler(handler), context(currContext) {}
+    Function(std::string name, std::vector<std::string> *args,
+             Context *context, FunctionPointer handler = nullptr) :
+            name(name), args(args), args_number(args->size()), handler(handler), context(context) {};
 
-    Element *eval(List *args) {
+    // Context here so that predefined functions can access it
+    Element *eval(Context* currContext, List *args) {
         return this->handler(this->context, args);
     }
 
@@ -87,19 +89,13 @@ private:
     std::vector<Element *> *body;
 public:
     CustomFunction(std::string name, std::vector<std::string> *args, std::vector<Element *> *body,
-                   Context *currContext) : Function(name, args, (CustomFunction::eval), currContext) {};
+                   Context *currContext) : Function(name, args, currContext) {};
 
-    static Element* eval(Context* context, List *args) {
+    Element *eval(Context *context, List *args) {
+
         // Context MUSTN'T be used here, for uniformity
 
         // if body is literal, simply return its value
-
-        // else if body is atom, try to look it up in context dict, and throw exception if does not exist
-        // but not good approach, since should bind the function to value in context when declared, not when called,
-        // as context may change
-        // better resolve value of literal before creating a function
-
-        // if it's a list, create new context (copy), execute statements one by one, return result.
     }
 };
 


### PR DESCRIPTION
There is base abstract class `Function` with attributes 
- `name`: function name
- `args`: list of names of arguments (if empty, pass empty vector, not `nullptr`)
- `args_number`: number of arguments required to invoke the function (derived from `args`)
- `lambda` (boolean): specifies whether this func is lambda

There are three types of concrete classes:
- `PredefinedFunction` inherits `Function`: used as a structure to store predefined function
- `CustomFunction` inherits `Function`: used to store user-defined functions
- `LambdaFunction` inherits `CustomFunction`: used for lambda functions 